### PR TITLE
Fix the proto import path in Android build file.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Android build file for building the library in AOSP
+// https://android.googlesource.com/platform/external/ukey2
+
 java_library {
   name: "ukey2",
   proto: {
     type: "lite",
+    include_dirs: ["external/ukey2/src/main/proto"],
   },
   srcs: [
     "**/*.proto",


### PR DESCRIPTION
This library gets mirrored onto AOSP in platform/external/ukey2.  Fixing
the proto import paths in the Android.bp file so building for AOSP
targets can be successful.