### PR TITLE
Fix Bazel support to compile C++ library

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,2 @@
-build --action_env=BAZEL_CXXOPTS=-std=c++17
+build --cxxopt=-std=c++17
+build --host_cxxopt=-std=c++17

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,3 +27,11 @@ http_archive(
     strip_prefix = "abseil-cpp-master",
     urls = ["https://github.com/abseil/abseil-cpp/archive/master.zip"],
 )
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "boringssl",
+    branch = "master-with-bazel",
+    remote = "https://boringssl.googlesource.com/boringssl",
+)


### PR DESCRIPTION
I had issues to compile the C++ library using Bazel:
- boringssl dependency was missing
- abseil could not run without setting c++17 version (the current config did not work on my machine)

Sending this PR to open a discussion if my configuration is correct. I've seen the bazel migration was done quite recently