### PR TITLE
Update bazel build to latest release.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
Update bazel build file to use cc_proto_library rule in protobuf instead of rules_cc.